### PR TITLE
Add THORChain asset token type

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,5 +32,9 @@ let package = Package(
                 .copy("Dumps"),
             ]
         ),
+        .testTarget(
+            name: "MarketKitTests",
+            dependencies: ["MarketKit"]
+        ),
     ]
 )

--- a/Sources/MarketKit/Classes/Models/BlockchainType.swift
+++ b/Sources/MarketKit/Classes/Models/BlockchainType.swift
@@ -21,6 +21,7 @@ public enum BlockchainType {
     case base
     case zkSync
     case stellar
+    case thorChain
     case unsupported(uid: String)
 
     public init(uid: String) {
@@ -47,6 +48,7 @@ public enum BlockchainType {
         case "base": self = .base
         case "zksync": self = .zkSync
         case "stellar": self = .stellar
+        case "thorchain": self = .thorChain
         default: self = .unsupported(uid: uid)
         }
     }
@@ -75,6 +77,7 @@ public enum BlockchainType {
         case .base: return "base"
         case .zkSync: return "zksync"
         case .stellar: return "stellar"
+        case .thorChain: return "thorchain"
         case let .unsupported(uid): return uid
         }
     }

--- a/Sources/MarketKit/Classes/Models/TokenRecord.swift
+++ b/Sources/MarketKit/Classes/Models/TokenRecord.swift
@@ -57,6 +57,7 @@ class TokenRecord: Record, Decodable, ImmutableMappable {
         case "eip20": reference >>> map["address"]
         case "bep2": reference >>> map["symbol"]
         case "spl": reference >>> map["address"]
+        case "thorchain": reference >>> map["address"]
         case "unsupported":
             if let reference {
                 reference >>> map["address"]

--- a/Sources/MarketKit/Classes/Models/TokenType.swift
+++ b/Sources/MarketKit/Classes/Models/TokenType.swift
@@ -19,6 +19,7 @@ public enum TokenType {
     case jetton(address: String)
     case stellar(code: String, issuer: String)
     case zanoAsset(id: String)
+    case thorChainAsset(denom: String)
     case unsupported(type: String, reference: String?)
 
     public init(type: String, reference: String? = nil) {
@@ -55,6 +56,11 @@ public enum TokenType {
             case "zano":
                 if let reference {
                     self = .zanoAsset(id: reference)
+                    return
+                }
+            case "thorchain":
+                if let reference {
+                    self = .thorChainAsset(denom: reference)
                     return
                 }
             default: ()
@@ -110,6 +116,7 @@ public enum TokenType {
                     return nil
                 }
             case "zano": self = .zanoAsset(id: chunks[1])
+            case "thorchain": self = .thorChainAsset(denom: chunks[1])
             case "unsupported": self = .unsupported(type: chunks[1], reference: nil)
             default: return nil
             }
@@ -141,6 +148,8 @@ public enum TokenType {
             return ["stellar", [code, issuer].joined(separator: "-")].joined(separator: ":")
         case let .zanoAsset(id):
             return ["zano", id].joined(separator: ":")
+        case let .thorChainAsset(denom):
+            return ["thorchain", denom].joined(separator: ":")
         case let .unsupported(type, reference):
             if let reference {
                 return ["unsupported", type, reference].joined(separator: ":")
@@ -160,6 +169,7 @@ public enum TokenType {
         case let .jetton(address): return (type: "the-open-network", reference: address)
         case let .stellar(code, issuer): return (type: "stellar", reference: [code, issuer].joined(separator: "-"))
         case let .zanoAsset(id): return (type: "zano", reference: id)
+        case let .thorChainAsset(denom): return (type: "thorchain", reference: denom)
         case let .unsupported(type, reference): return (type: type, reference: reference)
         }
     }

--- a/Tests/MarketKitTests/ThorChainMetadataTests.swift
+++ b/Tests/MarketKitTests/ThorChainMetadataTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import MarketKit
+
+final class ThorChainMetadataTests: XCTestCase {
+    func testThorChainTypeRoundTrip() {
+        XCTAssertEqual(BlockchainType(uid: "thorchain"), .thorChain)
+        XCTAssertEqual(BlockchainType.thorChain.uid, "thorchain")
+    }
+
+    func testNativeRuneMetadata() throws {
+        let kit = try Kit.instance(hsApiBaseUrl: "https://example.com")
+        let token = try XCTUnwrap(kit.token(query: TokenQuery(blockchainType: .thorChain, tokenType: .native)))
+
+        XCTAssertEqual(token.coin.uid, "thorchain")
+        XCTAssertEqual(token.coin.code, "RUNE")
+        XCTAssertEqual(token.type, .native)
+        XCTAssertEqual(token.decimals, 8)
+    }
+}


### PR DESCRIPTION
Adds the THORChain blockchain type and its bank-denom token type, with parsing both ways.